### PR TITLE
Fix vertion error

### DIFF
--- a/DndWhilePlaying/DndWhilePlaying.plugin.js
+++ b/DndWhilePlaying/DndWhilePlaying.plugin.js
@@ -20,16 +20,16 @@
                  discord_id: "678556376640913408",
              }
          ],
-         version: "0.0.1",
+         version: "0.0.2",
          description: "Automatically updates your status to Do Not Disturb when playing games and resets it back when stopped playing.",
          github: "https://github.com/QWERTxD/BetterDiscordPlugins/tree/main/DndWhilePlaying",
          github_raw: "https://raw.githubusercontent.com/QWERTxD/BetterDiscordPlugins/main/DndWhilePlaying/DndWhilePlaying.plugin.js",
      },
      changelog: [
          {
-             title: "Added",
-             type: "added",
-             items: ["Created Plugin"]
+             "title": "Bug Fix",
+             "type": "fixed",
+             "items": ["version fix"]
          }
      ]
  };


### PR DESCRIPTION
for some plugins like "PluginRepo" which updates the plugins automatically there is a problem with your plugins because the version in the configuration and the version in the comment at the beginning of the file are not coherent