### PR TITLE
Update DiscordActivities

### DIFF
--- a/DiscordActivities/index.js
+++ b/DiscordActivities/index.js
@@ -2,9 +2,8 @@ import { Patcher, WebpackModules } from '@zlibrary';
 import { GuildStore } from '@zlibrary/discord';
 import BasePlugin from '@zlibrary/plugin';
 
-const ExperimentUtils = WebpackModules.getByProps("overrideBucket");
-const activitiesExperiment = WebpackModules.getModule(m => m.definition.id === "2020-11_poker_night");
-const activities = WebpackModules.getByProps("GENERIC_EVENT_EMBEDDED_APPS");
+const activitiesExperiment = WebpackModules.getByProps("isActivitiesEnabled");
+const activities = WebpackModules.getByProps("YOUTUBE_APPLICATION_ID");
 
 export default class DiscordActivities extends BasePlugin {
     onStart() {
@@ -24,15 +23,18 @@ export default class DiscordActivities extends BasePlugin {
     }
 
     enableExperiment() {
-        ExperimentUtils.overrideBucket("2020-11_poker_night", 2);
-        Patcher.after(activitiesExperiment, 'useExperiment', (_this, [props], ret) => {
-            ret[0].enabledApplicationIds = [
+        const applicationIds = [
                 activities.POKER_NIGHT_APPLICATION_ID,
                 activities.CHESS_IN_THE_PARK_APPLICATION_ID,
                 activities.END_GAME_APPLICATION_ID,
                 activities.FISHINGTON_APPLICATION_ID,
                 activities.YOUTUBE_APPLICATION_ID
-            ];
-        })
+        ];
+        activitiesExperiment.getEnabledAppIds = function (e) {
+            return applicationIds;
+        };
+        activitiesExperiment.isActivitiesEnabled = function (e) {
+            return true;
+        };
     }
 }

--- a/DiscordActivities/package.json
+++ b/DiscordActivities/package.json
@@ -1,7 +1,7 @@
 {
     "info": {
         "name": "DiscordActivities",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "description": "Allows you to play Discord's Activity Games (Such as watching YouTube together and Chess) with friends in voice chats.",
         "authors": [
             {


### PR DESCRIPTION
Updates DiscordActivites to work with Discord Stable 100804.

Since the experiment seems to have been removed, I instead overrode the functions that determine which applications are available to declare all applications always available.

Fixes #97.