### PR TITLE
Update DiscordActivities for Stable 102113

### DIFF
--- a/DiscordActivities/index.js
+++ b/DiscordActivities/index.js
@@ -30,11 +30,11 @@ export default class DiscordActivities extends BasePlugin {
                 activities.WATCH_YOUTUBE_PROD_APP_ID,
                 activities.WATCH_YOUTUBE_DEV_APP_ID
         ];
-        activitiesExperiment.getEnabledAppIds = function (e) {
+        Patcher.instead(activitiesExperiment, "getEnabledAppIds", function (e) {
             return applicationIds;
-        };
-        activitiesExperiment.isActivitiesEnabled = function (e) {
+        });
+        Patcher.instead(activitiesExperiment, "isActivitiesEnabled", function (e) {
             return true;
-        };
+        });
     }
 }

--- a/DiscordActivities/index.js
+++ b/DiscordActivities/index.js
@@ -2,7 +2,7 @@ import { Patcher, WebpackModules } from '@zlibrary';
 import { GuildStore } from '@zlibrary/discord';
 import BasePlugin from '@zlibrary/plugin';
 
-const activitiesExperiment = WebpackModules.getByProps("isActivitiesEnabled");
+const activitiesExperiment = WebpackModules.getByProps("getEmbeddedActivitiesForUser");
 const activities = WebpackModules.getByProps("YOUTUBE_APPLICATION_ID");
 
 export default class DiscordActivities extends BasePlugin {
@@ -25,10 +25,10 @@ export default class DiscordActivities extends BasePlugin {
     enableExperiment() {
         const applicationIds = [
                 activities.POKER_NIGHT_APPLICATION_ID,
-                activities.CHESS_IN_THE_PARK_APPLICATION_ID,
                 activities.END_GAME_APPLICATION_ID,
                 activities.FISHINGTON_APPLICATION_ID,
-                activities.YOUTUBE_APPLICATION_ID
+                activities.WATCH_YOUTUBE_PROD_APP_ID,
+                activities.WATCH_YOUTUBE_DEV_APP_ID
         ];
         activitiesExperiment.getEnabledAppIds = function (e) {
             return applicationIds;

--- a/DiscordActivities/package.json
+++ b/DiscordActivities/package.json
@@ -1,7 +1,7 @@
 {
     "info": {
         "name": "DiscordActivities",
-        "version": "1.1.0",
+        "version": "1.1.1",
         "description": "Allows you to play Discord's Activity Games (Such as watching YouTube together and Chess) with friends in voice chats.",
         "authors": [
             {


### PR DESCRIPTION
In the time between my submitting of #99 and it being accepted, Discord was updated and some of the app IDs were shifted around. This commit accounts for that, allowing the menu to load again.

Since Chess in the Park seems to have been removed, the array had undefined in it, which confused the renderer and prevented any activities from being launched.

Youtube Together seems to have been deprecated in favor of Watch Together, so I replaced it.

![Screenshot 2021-10-22 144516](https://user-images.githubusercontent.com/9793218/138527074-603e5538-41ba-48a8-aca9-3d7bb676f810.png)
