### PR TITLE
Add more activites to DiscordActivites

### DIFF
--- a/DiscordActivities/index.js
+++ b/DiscordActivities/index.js
@@ -1,4 +1,4 @@
-import { Patcher, WebpackModules } from '@zlibrary';
+import { Patcher, WebpackModules, DiscordAPI, Toasts } from '@zlibrary';
 import { GuildStore } from '@zlibrary/discord';
 import BasePlugin from '@zlibrary/plugin';
 
@@ -24,17 +24,39 @@ export default class DiscordActivities extends BasePlugin {
 
     enableExperiment() {
         const applicationIds = [
-                activities.POKER_NIGHT_APPLICATION_ID,
-                activities.END_GAME_APPLICATION_ID,
-                activities.FISHINGTON_APPLICATION_ID,
-                activities.WATCH_YOUTUBE_PROD_APP_ID,
-                activities.WATCH_YOUTUBE_DEV_APP_ID
+            "755827207812677713",
+            "832012774040141894",
+            "832013003968348200",
+            "878067389634314250",
+            "879863976006127627",
+            "879863686565621790",
+            "852509694341283871",
+            "880218394199220334",
+            activities.END_GAME_APPLICATION_ID,
+            activities.FISHINGTON_APPLICATION_ID,
+            activities.WATCH_YOUTUBE_DEV_APP_ID
         ];
-        Patcher.instead(activitiesExperiment, "getEnabledAppIds", function (e) {
-            return applicationIds;
-        });
-        Patcher.instead(activitiesExperiment, "isActivitiesEnabled", function (e) {
-            return true;
-        });
+        const gameGuildId = "831646372519346186";
+        var isInGameGuild = DiscordAPI.Guild.fromId(gameGuildId);
+        if (isInGameGuild == undefined) {
+            Patcher.instead(activitiesExperiment, "getEnabledAppIds", (function() {
+                return applicationIds;
+            }));
+        } else {
+            WebpackModules.getByProps("fetchEmbeddedActivities").fetchEmbeddedActivities("831646372519346186");
+            Patcher.before(activitiesExperiment, "getEnabledAppIds", (function(_, args) {
+                args[0] = gameGuildId;
+            }));
+            Patcher.after(activitiesExperiment, "getEnabledAppIds", (function(_, __, ret) {
+                if (ret[ret.length - 1] != activities.WATCH_YOUTUBE_DEV_APP_ID) {
+                    ret.push(activities.END_GAME_APPLICATION_ID);
+                    ret.push(activities.FISHINGTON_APPLICATION_ID);
+                    ret.push(activities.WATCH_YOUTUBE_DEV_APP_ID);
+                    if (ret.length !== applicationIds.length || !ret.every(function(value, index) { return value === applicationIds[index]})) {
+                        Toasts.show("DiscordActivities: redownloaded activities list", "warning");
+                    }
+                }
+            }));
+        }
     }
 }

--- a/DiscordActivities/index.js
+++ b/DiscordActivities/index.js
@@ -2,7 +2,7 @@ import { Patcher, WebpackModules } from '@zlibrary';
 import { GuildStore } from '@zlibrary/discord';
 import BasePlugin from '@zlibrary/plugin';
 
-const activities = WebpackModules.getByProps("getEmbeddedActivitiesForUser");
+const activities = WebpackModules.getByProps("getSelfEmbeddedActivities");
 
 export default class DiscordActivities extends BasePlugin {
     onStart() {
@@ -48,8 +48,8 @@ export default class DiscordActivities extends BasePlugin {
             "832012682520428625",
             "832013108234289153",
         ];
-        Patcher.instead(activities, "getEnabledAppIds", (function() {
+        Patcher.instead(activities, "getEnabledAppIds", function() {
             return applicationIds;
-        }));
+        });
     }
 }

--- a/DiscordActivities/index.js
+++ b/DiscordActivities/index.js
@@ -1,14 +1,13 @@
-import { Patcher, WebpackModules, DiscordAPI, Toasts } from '@zlibrary';
+import { Patcher, WebpackModules } from '@zlibrary';
 import { GuildStore } from '@zlibrary/discord';
 import BasePlugin from '@zlibrary/plugin';
 
-const activitiesExperiment = WebpackModules.getByProps("getEmbeddedActivitiesForUser");
-const activities = WebpackModules.getByProps("YOUTUBE_APPLICATION_ID");
+const activities = WebpackModules.getByProps("getEmbeddedActivitiesForUser");
 
 export default class DiscordActivities extends BasePlugin {
     onStart() {
         this.patchGuildRegion();
-        this.enableExperiment();
+        this.patchEnabledAppIds();
     }
 
     onStop() {
@@ -22,8 +21,9 @@ export default class DiscordActivities extends BasePlugin {
         })
     }
 
-    enableExperiment() {
+    patchEnabledAppIds() {
         const applicationIds = [
+            // Prod
             "755827207812677713",
             "832012774040141894",
             "832013003968348200",
@@ -32,31 +32,24 @@ export default class DiscordActivities extends BasePlugin {
             "879863686565621790",
             "852509694341283871",
             "880218394199220334",
-            activities.END_GAME_APPLICATION_ID,
-            activities.FISHINGTON_APPLICATION_ID,
-            activities.WATCH_YOUTUBE_DEV_APP_ID
+            "773336526917861400",
+            "814288819477020702",
+            "879864070101172255",
+            "879863881349087252",
+            "832012854282158180",
+            // Dev
+            "763133495793942528",
+            "880218832743055411",
+            "878067427668275241",
+            "879864010126786570",
+            "879864104980979792",
+            "891001866073296967",
+            "832012586023256104",
+            "832012682520428625",
+            "832013108234289153",
         ];
-        const gameGuildId = "831646372519346186";
-        var isInGameGuild = DiscordAPI.Guild.fromId(gameGuildId);
-        if (isInGameGuild == undefined) {
-            Patcher.instead(activitiesExperiment, "getEnabledAppIds", (function() {
-                return applicationIds;
-            }));
-        } else {
-            WebpackModules.getByProps("fetchEmbeddedActivities").fetchEmbeddedActivities("831646372519346186");
-            Patcher.before(activitiesExperiment, "getEnabledAppIds", (function(_, args) {
-                args[0] = gameGuildId;
-            }));
-            Patcher.after(activitiesExperiment, "getEnabledAppIds", (function(_, __, ret) {
-                if (ret[ret.length - 1] != activities.WATCH_YOUTUBE_DEV_APP_ID) {
-                    ret.push(activities.END_GAME_APPLICATION_ID);
-                    ret.push(activities.FISHINGTON_APPLICATION_ID);
-                    ret.push(activities.WATCH_YOUTUBE_DEV_APP_ID);
-                    if (ret.length !== applicationIds.length || !ret.every(function(value, index) { return value === applicationIds[index]})) {
-                        Toasts.show("DiscordActivities: redownloaded activities list", "warning");
-                    }
-                }
-            }));
-        }
+        Patcher.instead(activities, "getEnabledAppIds", (function() {
+            return applicationIds;
+        }));
     }
 }


### PR DESCRIPTION
Implements improvement suggested in #103 .

Since Discord seems to have moved away from putting ID constants in a Webpack module, this uses IDs from [GeneralSadaf's gist](https://gist.github.com/GeneralSadaf/42d91a2b6a93a7db7a39208f2d8b53ad).

I am not certain as to how exactly the list was obtained, as the ACTIVITY_GUILD_CONFIG endpoint only returns the list of publicly available activities, and ACTIVITIES returns rich presence activities. As such, I used a predefined list instead of patching fetchEmbeddedActivites like I wanted to.