### PR TITLE
I have fixed and improved the plugin DndWhilePlaying

### DIFF
--- a/DndWhilePlaying/DndWhilePlaying.plugin.js
+++ b/DndWhilePlaying/DndWhilePlaying.plugin.js
@@ -68,7 +68,7 @@
          async runningGamesChange(event) {
              const { games } = event;
              if(games.length > 0) {
-                 const StatusStore = BdApi.findModuleByProps('getStatus');
+                 const StatusStore = BdApi.findModuleByProps('getStatus', 'getState');
                  const currentUser = BdApi.findModuleByProps('getCurrentUser').getCurrentUser();
                  const status = StatusStore.getStatus(currentUser.id);
                  if(status === 'dnd') return;

--- a/DndWhilePlaying/DndWhilePlaying.plugin.js
+++ b/DndWhilePlaying/DndWhilePlaying.plugin.js
@@ -72,6 +72,7 @@
                  const currentUser = BdApi.findModuleByProps('getCurrentUser').getCurrentUser();
                  const status = StatusStore.getStatus(currentUser.id);
                  if(status === 'dnd') return;
+                 if(status === 'invisible') return;
                  await BdApi.saveData("DndWhilePlaying", "status", status)
                  BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: "dnd"})
              }else if(games.length == 0){

--- a/DndWhilePlaying/DndWhilePlaying.plugin.js
+++ b/DndWhilePlaying/DndWhilePlaying.plugin.js
@@ -71,11 +71,13 @@
                  const StatusStore = BdApi.findModuleByProps('getStatus', 'getState');
                  const currentUser = BdApi.findModuleByProps('getCurrentUser').getCurrentUser();
                  const status = StatusStore.getStatus(currentUser.id);
-                 if(status === 'dnd') return;
                  if(status === 'invisible') return;
-                 await BdApi.saveData("DndWhilePlaying", "status", status)
-                 BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: "dnd"})
+                 if(BdApi.getData("DndWhilePlaying", "inGame") !== true) await BdApi.saveData("DndWhilePlaying", "status", status);
+                 await BdApi.saveData("DndWhilePlaying", "inGame", true);
+                 if(status !== "dnd") BdApi.findModuleByProps("updateRemoteSettings").updateRemoteSettings({ status: "dnd" });
+                 
              }else if(games.length == 0){
+                 await BdApi.saveData("DndWhilePlaying", "inGame", false);
                  const savedStatus = BdApi.getData("DndWhilePlaying", "status");
                  BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: savedStatus})
              }


### PR DESCRIPTION
### Hello, Happy New Year!

I think Discord should have the built-in functionality that your `DndWhilePlaying` plugin gives.

I am posting 3 commits:
1. I fixed getting the current user status. This was not working properly before ([see here](https://imgur.com/a/3YOoMyO)).
2. I disabled changing the status to `dnd` when the user is `invisible`.
3. I fixed returning to the previous status. When the user has `dnd` status and turns on the game, then only the `inGame` variable changes. This is responsible for not overwriting the previous status with the `dnd` status when multiple games are enabled at once.

#### That's it for today, glad I could help ;D