### PR TITLE
Fixed a bug related to invisible status

### DIFF
--- a/DndWhilePlaying/DndWhilePlaying.plugin.js
+++ b/DndWhilePlaying/DndWhilePlaying.plugin.js
@@ -82,9 +82,9 @@
                  
              }else if(games.length == 0){
                  const savedStatus = BdApi.getData("DndWhilePlaying", "status");
-                 BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: savedStatus});
+                 if (savedStatus) BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: savedStatus});
 
-                 await BdApi.saveData("DndWhilePlaying", "status", "");
+                 await BdApi.saveData("DndWhilePlaying", "status", false);
                  await BdApi.saveData("DndWhilePlaying", "inGame", false);
              }
          }

--- a/DndWhilePlaying/DndWhilePlaying.plugin.js
+++ b/DndWhilePlaying/DndWhilePlaying.plugin.js
@@ -67,19 +67,25 @@
  
          async runningGamesChange(event) {
              const { games } = event;
+          
+             const StatusStore = BdApi.findModuleByProps('getStatus', 'getState');
+             const currentUser = BdApi.findModuleByProps('getCurrentUser').getCurrentUser();
+             const status = StatusStore.getStatus(currentUser.id);
+             if(status === 'invisible') return;
+
              if(games.length > 0) {
-                 const StatusStore = BdApi.findModuleByProps('getStatus', 'getState');
-                 const currentUser = BdApi.findModuleByProps('getCurrentUser').getCurrentUser();
-                 const status = StatusStore.getStatus(currentUser.id);
-                 if(status === 'invisible') return;
-                 if(BdApi.getData("DndWhilePlaying", "inGame") !== true) await BdApi.saveData("DndWhilePlaying", "status", status);
-                 await BdApi.saveData("DndWhilePlaying", "inGame", true);
+                 if(BdApi.getData("DndWhilePlaying", "inGame") !== true) {
+                     await BdApi.saveData("DndWhilePlaying", "status", status);
+                     await BdApi.saveData("DndWhilePlaying", "inGame", true);
+                 }
                  if(status !== "dnd") BdApi.findModuleByProps("updateRemoteSettings").updateRemoteSettings({ status: "dnd" });
                  
              }else if(games.length == 0){
-                 await BdApi.saveData("DndWhilePlaying", "inGame", false);
                  const savedStatus = BdApi.getData("DndWhilePlaying", "status");
-                 BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: savedStatus})
+                 BdApi.findModuleByProps('updateRemoteSettings').updateRemoteSettings({status: savedStatus});
+
+                 await BdApi.saveData("DndWhilePlaying", "status", "");
+                 await BdApi.saveData("DndWhilePlaying", "inGame", false);
              }
          }
  


### PR DESCRIPTION
While turning on the game while being `online`, it set the `status` value in memory. You set the status invisible, then turn on the game. When you turn off this game, the last set status, which is `online`, is loaded.

**I have fixed this bug.** When the status is `invisible`, the plugin will not perform any actions.