### PR TITLE
[InAppNotifications] Discriminator display changes

### DIFF
--- a/InAppNotifications/InAppNotifications.plugin.js
+++ b/InAppNotifications/InAppNotifications.plugin.js
@@ -809,10 +809,8 @@ module.exports = !global.ZeresPluginLibrary
           if (!this.supposedToNotify(message, channel) && !keywordFound) return;
           let authorString = "";
           let authorName = `${author.globalName} (${author.discriminator === "0" ? author.username : author.tag})`;
-          if (author.globalName === null) {
+          if (author.globalName === null || author.globalName.toLowerCase() === author.username.toLowerCase()) {
             authorName = author.discriminator === "0" ? author.username : author.tag;
-          } else if (author.globalName.toLowerCase() === author.username.toLowerCase()) {
-            authorName = author.globalName;
           }
           if (channel.guild_id) {
             const guild = GuildStore.getGuild(channel.guild_id);
@@ -1060,7 +1058,7 @@ module.exports = !global.ZeresPluginLibrary
               "Accepted your friend request.",
             ],
             {
-              author: user.discriminator === "0" ? user.tag.split("#")[0] : user.tag,
+              author: user.discriminator === "0" ? user.username : user.tag,
               avatar: user.getAvatarURL(),
               onClick: () => {
                 UserProfileModals.open(user.id);

--- a/InAppNotifications/InAppNotifications.plugin.js
+++ b/InAppNotifications/InAppNotifications.plugin.js
@@ -3,7 +3,7 @@
  * @source https://github.com/QWERTxD/BetterDiscordPlugins/blob/main/InAppNotifications/InAppNotifications.plugin.js
  * @updateUrl https://raw.githubusercontent.com/QWERTxD/BetterDiscordPlugins/main/InAppNotifications/InAppNotifications.plugin.js
  * @website https://github.com/QWERTxD/BetterDiscordPlugins/tree/main/InAppNotifications
- * @version 1.1.3
+ * @version 1.1.4
  */
 const request = require("request");
 const fs = require("fs");
@@ -27,10 +27,10 @@ const config = {
 	},
   changelog: [
     {
-      "title": "Fixed",
-      "type": "fixed",
+      "title": "Discriminators",
+      "type": "added",
       "items": [
-        "Fixed the plugin. thanks to davilarek",
+        "Modified how usernames and display names are displayed in notifications.",
       ]
     }
   ],
@@ -808,6 +808,12 @@ module.exports = !global.ZeresPluginLibrary
           const keywordFound = this.checkKeywords(message);
           if (!this.supposedToNotify(message, channel) && !keywordFound) return;
           let authorString = "";
+          let authorName = `${author.globalName} (${author.discriminator === "0" ? author.username : author.tag})`;
+          if (author.globalName === null) {
+            authorName = author.discriminator === "0" ? author.username : author.tag;
+          } else if (author.globalName.toLowerCase() === author.username.toLowerCase()) {
+            authorName = author.globalName;
+          }
           if (channel.guild_id) {
             const guild = GuildStore.getGuild(channel.guild_id);
             const colorString = GuildMemberStore.getMember(
@@ -824,22 +830,22 @@ module.exports = !global.ZeresPluginLibrary
                       display: "inline",
                     },
                   },
-                  author.tag
+                  authorName
                 ),
                 ` (${guild.name}, #${channel.name})`,
               ];
             } else {
-              authorString = `${author.tag} (${guild.name}, #${channel.name})`;
+              authorString = `${authorName} (${guild.name}, #${channel.name})`;
             }
           }
           if (channel.type === ChannelTypes["GROUP_DM"]) {
-            authorString = `${author.tag} (${channel.name})`;
+            authorString = `${authorName} (${channel.name})`;
 			if (!channel.name || channel.name === " " || channel.name === "") {
-              authorString = `${author.tag} (${channel.rawRecipients.map((e) => e.username).join(", ")})`;
+              authorString = `${authorName} (${channel.rawRecipients.map((e) => e.username).join(", ")})`;
             }
           }
           if (channel.type === ChannelTypes["DM"]) {
-            authorString = `${author.tag}`;
+            authorString = `${authorName}`;
           }
 
           if (message.call) {
@@ -1054,7 +1060,7 @@ module.exports = !global.ZeresPluginLibrary
               "Accepted your friend request.",
             ],
             {
-              author: user.tag,
+              author: user.discriminator === "0" ? user.tag.split("#")[0] : user.tag,
               avatar: user.getAvatarURL(),
               onClick: () => {
                 UserProfileModals.open(user.id);


### PR DESCRIPTION
Most Discord users have migrated to the new username system (discriminator of #0000), and this plugin will always show this discriminator, which is unnecessary.

These changes will display the global display name alongside the username unless they are the same, in which case the username will be displayed. Users still on the old discriminator system/without a set global nickname is also handled.

**Example notification header**
Old: `username#discrim ...`
New: `displayname (username#discrim) ...`, where displayname will be shown if it is different from the username, and discriminator only shown if required.