### PR TITLE
Fixes InAppNotifications not working due to missing raw message module

### DIFF
--- a/InAppNotifications/InAppNotifications.plugin.js
+++ b/InAppNotifications/InAppNotifications.plugin.js
@@ -21,16 +21,16 @@ const config = {
         ],
     github_raw:
       "https://raw.githubusercontent.com/QWERTxD/BetterDiscordPlugins/main/InAppNotifications/InAppNotifications.plugin.js",
-    version: "1.1.5",
+    version: "1.1.6",
     description:
       "Displays notifications such as new messages, friends added in Discord.",
 	},
   changelog: [
     {
-      "title": "Discriminators",
-      "type": "added",
+      "title": "Fixed",
+      "type": "fixed",
       "items": [
-        "Modified how usernames and display names are displayed in notifications.",
+        "Fixes plugin not working due to missing raw message module",
       ]
     }
   ],
@@ -208,7 +208,7 @@ const config = {
 
       const ChannelTypes = Webpack.getModule(Webpack.Filters.byProps("GUILD_TEXT"), { searchExports: true });
       const MuteStore = WebpackModules.getByProps("isSuppressEveryoneEnabled");
-      const isMentioned = Webpack.getModule(x=>x.isRawMessageMentioned)
+      const isRawMessageMentioned = Webpack.getModule(Webpack.Filters.byStrings("userId", "channelId", "mentionEveryone", "mentionUsers", "mentionRoles", "suppressEveryone", "suppressRoles"), { searchExports: true });
       const Markdown = WebpackModules.getByProps("parse", "parseTopic");
       const GuildStore = Webpack.getStore("GuildStore")
       const AckUtils = { ack: Webpack.getModule(Webpack.Filters.byStrings("CHANNEL_ACK"), { searchExports: true }) };
@@ -993,7 +993,7 @@ const config = {
             message.guild_id || "@me"
           );
           if (MuteStore.allowAllMessages(channel)) return true;
-          const SomethingHereShrug = isMentioned.isRawMessageMentioned(
+          const SomethingHereShrug = isRawMessageMentioned(
             {
               rawMessage: message,
               userId: UserStore.getCurrentUser().id,


### PR DESCRIPTION
# Changes
Hooks onto the `s(e)` function. I'm not that versed with the BD API, but I looked through the webpack and found that the following filters returned the appropriate function that fixed InAppNotifications for me. I haven't experienced any issues (yet), so I would appreciate it if someone else could also test this just to confirm things are in fact working for everyone.

New hook: `Webpack.getModule(Webpack.Filters.byStrings("userId", "channelId", "mentionEveryone", "mentionUsers", "mentionRoles", "suppressEveryone", "suppressRoles"), { searchExports: true });`

![image](https://github.com/QWERTxD/BetterDiscordPlugins/assets/6964154/6f124cdf-e388-4b33-b3f5-f767a160238a)


### Additional Information

As I said, I'm not too familiar with hooking into functions so I wasn't sure how to make it such that I retrieve the parent function such that `SomethingHereShrug` changes from `isMentioned.isRawMessageMentioned` => `isRawMessageMentioned`, but I guess this PR works fine too albeit no _proper_ `#isRawMessageMentioned` definition via the parent (if that makes sense).
Other potential hits: `Webpack.getModules(Webpack.Filters.byStrings("userId", "channelId", "mentionEveryone", "mentionUsers", "mentionRoles", "suppressEveryone", "suppressRoles"), { searchExports: true });`

The workaround in https://github.com/QWERTxD/BetterDiscordPlugins/pull/397 works just fine, but I figured I would take a shot at looking into the webpack to see if I can find the hook again after reading the comments mentioning how `isRawMessageMentioned` may have been removed. I thought by calling it directly there would be some performance increase albeit negligible, but it seems like both the workaround and directly calling is essentially the same judging by the `l` function. Nonetheless, again, the performance is probably negligible.